### PR TITLE
Pivot RFC to generic framework for `box` and annotations

### DIFF
--- a/0022-circuit-block.md
+++ b/0022-circuit-block.md
@@ -277,7 +277,7 @@ This might naturally extend to such a `BackendV3` providing the additional infor
 We envision two main workflows that users will follow once `Box`es become available, one for regular users and another one for power users:
 
 1. The workflow for regular users:
-    - Users initialize a `QuantumCircuit` without blocks, as they do today.
+    - Users initialize a `QuantumCircuit` without boxes, as they do today.
     - They apply all of the desired transpiler passes, for example to map the circuit to an ISA circuit for the backend that they wish to use.
     - They use (a convenience method built around) a new transpiler pass that collects the circuit's gates into boxes, with the ability of specifying different collection strategies.
     - They submit their job.

--- a/0022-circuit-block.md
+++ b/0022-circuit-block.md
@@ -30,7 +30,7 @@ The nearest-term use cases for this are:
 
 * have a grouping construction to simplify stretch-based scheduling in Qiskit SDK
 * allow advanced users to specify the noise-learning and twirling blocks IBM Primitives error mitigation should use, and the per-block strategy
-* allow regular uses to see what blocks the IBM Primitives divided their circuit into for noise learning and twirling
+* allow regular users to see what blocks the IBM Primitives divided their circuit into for noise learning and twirling
 
 
 ## `Box`: a one-off grouping of instructions

--- a/0022-circuit-block.md
+++ b/0022-circuit-block.md
@@ -8,7 +8,7 @@
 
 ## Summary
 
-Introduce a way grouping of instructions to Qiskit SDK that can have downstream data attached, pass through transpilation, and up and down an execution stack.
+Introduce a way of grouping instructions in Qiskit SDK that can have downstream data attached, pass through transpilation, and up and down an execution stack.
 The case-study use of this is for Qiskit Runtime primitives to provide more flexibility and transparency in Pauli twirling and error mitigation.
 
 Qiskit does not currently have the concept of a "grouping" of instructions, other than as a user-defined custom gate.

--- a/0022-circuit-block.md
+++ b/0022-circuit-block.md
@@ -50,7 +50,7 @@ Aside from variable scoping concerns and the resolution of delay lengths, the ex
 
 A `box` can be seen as the trivial case of a control-flow operation, equivalent to an `if (true)` block in a control-flow graph.
 Box, however, additionally has the semantics that is not a valid optimisation to simply remove the box.
-A `box` is a non-resuable grouping of instructions; it is not a function call that can be called multiple times (this is still a useful concept, it's just separate to `box` and not addressed here).
+A `box` is a non-reusable grouping of instructions; it is not a function call that can be called multiple times (this is still a useful concept, it's just separate to `box` and not addressed here).
 
 With this in mind, the most straightforward path to implementation in Qiskit SDK is to make `Box` a `ControlFlowOp`.
 Almost all of the desired semantics will automatically be inherited, and this fits in with existing objects, rather than requiring new special casing paths.

--- a/0022-circuit-block.md
+++ b/0022-circuit-block.md
@@ -8,32 +8,278 @@
 
 ## Summary
 
-Objective: Introduce a new `Block` instruction to enhance the user experience with Qiskit's Runtime primitives, with the goal of providing more flexibility and transparency with respect to twirling and mitigation.
+Introduce a way grouping of instructions to Qiskit SDK that can have downstream data attached, pass through transpilation, and up and down an execution stack.
+The case-study use of this is for Qiskit Runtime primitives to provide more flexibility and transparency in Pauli twirling and error mitigation.
 
-The concept of a block of gates is fundamental to many quantum computing routines. For example, a block is a natural concept when reasoning about quantum errors because the error profile often depends on factors such as which gates are applied simultaneously. However, Qiskit does not provide a dedicated object to represent a block. Traditionally, users have worked around this by defining blocks *indirectly* using barriers. While this approach has been adequate for tasks like scheduling and transpilation, barriers can be hard to parse when pre-processing circuits in preparation for twirling or mitigation. Suboptimal handling of barriers in these post-processing steps can introduce significant slowdowns in some mitigation experiments (for example, it can unnecessarily increase the time required by the noise learning steps) and produce outcomes that may seem unintuitive to typical users.
+Qiskit does not currently have the concept of a "grouping" of instructions, other than as a user-defined custom gate.
+However, the ability to group certain instructions to appear as a "block" in a larger context is important for many compilation tasks:
 
-To overcome these issues, we propose to establish the concept of a block of gates through the introduction of a new `Block` instruction class. The primary goal of this class is to encapsulate an isolated block of `CircuitInstruction`s, treating it as a single unit for tasks like twirling and mitigation. We believe that `Block`s will offer:
-* Transparency: 
-  * Users will be able to learn how their circuits are broken into blocks, twirled, and mitigated *before* running a job
-  (today, they can only find this out once the job is done).
-* Flexibility: 
-  * Users will be able to draw blocks around any combination of instructions that they want to be grouped together for the purpose of twirling or mitigation (today, all blocks are effectively layers, i.e., depth-one blocks).
-* Extensibility:
-  * A block instance can own a context that can, for example, allow users to specify a twirling group such as "Pauli" and a twirling strategy such as "active-accum" that can potentially be different for each block (today, this can only be done at the circuit level). We can introduce allowed features to the context as necessary, and have definitions for what features the runtime supports.
-* Ability to assign a handle to each unique block that enables user to target noise models against handles to be used in mitigation or simulation (today, there is no clean way of doing this, and usually involves an unsafe hash of a quantum circuit object, fragile indexing, or human introspection).
+* a block of several gates might have a known unitary action, and can be treated as atomic for commutation purposes, even if a candidate gate doesn't commute with each block element individually.
+* noise-learning techniques might be applied to simultaneous logical blocks of operations, rather than individual 2q hardware gates.
+* a user might wish to Pauli twirl around a block of instructions, rather than a single one.
+* a block of instructions might be assigned some duration as part of a larger circuit, and internally it is scheduled with stretchable durations to implement optimal dynamic decoupling spacing without increasing the complexity of the outer scheduling problem.
 
-## `Block`: Definition and use cases
+Several downstream projects of Qiskit have made ad-hoc blocks by using labelled `Barrier` instructions, but this optimisation barrier has further effects than simple grouping, and the single-sided nature of it makes it very hard to work with as an actual "grouping" construct.
+`Barrier`s also are very hard for users to interpret when inspecting circuits after compilation.
 
-A `Block` represents an isolated block of `CircuitInstruction`s that is treated as a single unit in the context of twirling and mitigation. In more detail, when a circuit contains blocks:
-- Twirling targets the blocks and ignores all the circuit instructions that live outside of the blocks.
-- Noise learning targets the blocks and ignores all the circuit instructions that live outside of the blocks.
-- Gate mitigation (e.g. PEC and PEA) targets the blocks and ignores all the circuit instructions that live outside of the blocks.
+The RFC proposes to add a new `Box` instruction to Qiskit, whose semantics will be very similar to the `box` concept from OpenQASM 3.
+This `Box` should be able to pass through the Qiskit compiler (under certain limitations), be QPY serialisable, and be able to be transmitted up and down execution stacks.
+We will examine how this `Box` might also permit downstream "annotations", outside of the control of the Qiskit SDK compiler, and how the compiler will still be able to reason about such annotations.
 
-We envision two main workflows that users will follow once `Block`s become available, one for regular users and another one for power users:
+The nearest-term use cases for this are:
+
+* have a grouping construction to simplify stretch-based scheduling in Qiskit SDK
+* allow advanced users to specify the noise-learning and twirling blocks IBM Primitives error mitigation should use, and the per-block strategy
+* allow regular uses to see what blocks the IBM Primitives divided their circuit into for noise learning and twirling
+
+
+## `Box`: a one-off grouping of instructions
+
+As in OpenQASM 3, a `Box` will be:
+
+* a group of non-overlapping (but potentially nested) circuit instructions,
+* which introduces a new scope for declared variables,
+* which can have internal scheduling within itself, but it scheduled atomically within the circuit (i.e. all wires touched within the box are delayed to match the critical path length),
+* which forbids optimisations from crossing from outside to inside the box or vice-versa, but permits optimisations across the entire box,
+* and can have arbitrary backend- and SDK-agnostic annotations attached to it.
+
+A `box` can contain any other Qiskit circuit instruction.
+Aside from variable scoping concerns and the resolution of delay lengths, the execution of a circuit containing a `box` should be the same as the execution of the same circuit with the boxed instructions inlined into the circuit.
+
+### How to implement in Qiskit
+
+A `box` can be seen as the trivial case of a control-flow operation, equivalent to an `if (true)` block in a control-flow graph.
+Box, however, additionally has the semantics that is not a valid optimisation to simply remove the box.
+A `box` is a non-resuable grouping of instructions; it is not a function call that can be called multiple times (this is still a useful concept, it's just separate to `box` and not addressed here).
+
+With this in mind, the most straightforward path to implementation in Qiskit SDK is to make `Box` a `ControlFlowOp`.
+Almost all of the desired semantics will automatically be inherited, and this fits in with existing objects, rather than requiring new special casing paths.
+
+Some additional implications of this:
+
+* Aer will need to be taught to "unwrap" `box` instructions as part of its control-flow handling.
+  This should be straightforwards.
+* Hardware vendors may need to tell Qiskit they understand `box`, similarly to how they put `IfElseOp` in their `Target` instances
+* Qiskit's Sabre layout and routing may want to relax its requirement that a control-flow scope has the same layout at the start and end; for single scopes that dominate all following basic blocks, this is unnecessary and can cause performance problems.
+* Qiskit's `qiskit.circuit.CONTROL_FLOW_OP_NAMES` will need updating.
+
+The actual implementation of the object looks something like
+
+```python
+import typing
+from qiskit.circuit.controlflow import ControlFlowOp
+
+@typing.Final
+class Box(ControlFlowOp):
+    def __init__(self, circuit, annotations):
+        super().__init__("box", circuit.num_qubits, circuit.num_clbits, [circuit])
+        self.annotations = annotations
+
+    @property
+    def blocks(self):
+        return (self.params[0],)
+
+    def replace_blocks(self, blocks):
+        assert len(blocks) == 1
+        return Box(blocks[0], self.annotations.copy())
+```
+
+See below for more considerations about the ``annotations`` parameter.
+
+This then implies that Qiskit should implement the control-flow builder interfaces for `box`.
+Again, using some dummy "annotations" (which are not specified by this RFC, and are given for illustrative purposes only):
+```python
+from qiskit.circuit import QuantumCircuit
+
+# Hypothetical core-Qiskit box-level annotation.
+from qiskit.transpiler.contexts import ScheduleStrategy
+# Hypothetical annotations for IBM-specific primitives.
+from qiskit_ibm_runtime.contexts import TwirlingStrategy
+
+qc = QuantumCircuit(5, 5)
+with qc.box([ScheduleStrategy.ALAP, TwirlingStrategy(...)]):
+    qc.h(0)
+    qc.cx(0, 1)
+    qc.x(2)
+with qc.box([ScheduleStrategy.ASAP, TwirlingStrategy(...)]):
+    qc.h(2)
+    qc.cx(2, 3)
+    qc.x(4)
+qc.measure(qc.qubits, qc.clbits)
+```
+
+For `box` in particular (but also for other control-flow operations), it can be useful to mark certain qubits and other circuit resources as being explicitly "used" by a block, even if the actual operation is a no-op.
+For example, twirling and noise learning may want to consider certain qubits along with a complete block, even if that qubit is undergoing the logical identity for the span.
+This can be worked around by inserting explicit `id` gates into the box, or some other form of no-op operation, but these instructions can sometimes be treated by hardware as something other than a no-op, which might cause performance problems if the compiler fails to optimise them out or understand their intention.
+For example, IBM hardware has, in the past, treated the `id` instruction as a single-cycle delay on a single qubit, which is not precisely equal to a no-op for the purposes of scheduling, especially if the rest of the block has a natural duration of zero cycles (such as if it comprises only virtual phase update `rz` gates).
+We also do not currently have the concept of a no-op on classical data.
+To make the user intent clearer here, we propose adding a `QuantumCircuit.noop` to make the intent explicit:
+
+> [!NOTE]
+> *Bikeshedding potential*: do you prefer `QuantumCircuit.use` or `QuantumCircuit.noop` for this?
+> `use` is perhaps clearer for more users, but its name only makes sense in a control-flow builder context, whereas `noop` makes sense to appear in the root scope of a `QuantumCircuit`.
+
+```python
+from qiskit.circuit import QuantumCircuit
+qc = QuantumCircuit(3, 3)
+with qc.box():
+    # This `box` will be full-width on the circuit, despite every qubit and clbit undergoing the identity.
+    qc.noop(*qc.qubits, *qc.clbits)
+```
+
+The `noop` (or `use`) instruction will do the standard Qiskit circuit error checking to validate its inputs are valid resources for the circuit, but will not cause a new entry in the instruction list.
+The control-flow builders will still pick this up as a "used" resource.
+
+
+### Transpiler semantics of `box`
+
+The transpiler must fail if the backend reports that it cannot handle the `box` instruction, as for other control-flow operations.
+In the absence of any annotations, the transpiler must retain any boxes in the input circuit, and the content of the box must be transpiled up to the same equivalent and hardware-compatibility guarantees that the rest of the tranpsiler guarantees, as if the boxed content was a stand-alone circuit (e.g. a unitary operation must have the same action before and after compilation, up to layout and routing effects, and all gates must be ISA supported).
+
+Transpiler passes are permitted to insert new boxes around instruction groups.
+A `box` may only be removed (and replaced by some representation of its body) by a transpiler pass if the annotations on the `box` permit it (see below).
+The default should be to assume that the `box` cannot be removed.
+
+
+## Annotations on `box`
+
+In the above, we have talked about annotations on the `box`.
+This is by analogy to the OpenQASM 3 concept.
+In more generic terms, an annotation will be
+
+> a compiler directive applied in a limited scope
+
+For this RFC, we only consider annotations on `box`es, but in the future, this may be expanded to other general instructions.
+
+Annotations may affect how the scope of the body is compiled.
+For example, an annotation may mark that one `box` should be scheduled using an ALAP schedule internally, regardless of how the outer scope of the circuit is being scheduled.
+Such an annotation may live inside Qiskit SDK.
+
+Other use cases for `box` may have downstream transpiler passes introduce new `box`es with annotations that may be consumed by some later point in their compilation stack.
+For example, IBM's primitives implementations may want to create blocks around blocks of instructions that will undergo noise learning as a single entity, and annotated these boxes with identifiers and strategies around the noise learning, for consumption by a lower part of its own stack.
+Qiskit SDK must provide a framework such that transpiler passes can function in the presence of annotations that they don't necessarily understand entirely.
+
+> [!NOTE]
+> This section is definitely not complete yet; the text of it just represents a starting point for the thinking.
+
+### Semantics of custom
+
+Qiskit SDK may (in the future, not in this RFC) supply some core directives, such as the hypothetical `ScheduleStrategy` one used above, which affect Qiskit's built-in compiler passes.
+More generally, these may be defined by any compiler pass author, and the API must be fixed so that other passes know what they may/may not do with an annotated box.
+
+The extremes are:
+
+1. any compiler pass is allowed to entirely ignore any annotation it doesn't understand, provided it leaves the annotation in place for a later pass.
+2. a compiler pass is forbidden to act on a box unless it declares that it understands all annotations attached to it.
+3. the annotation somehow declares what compiler passes are allowed to run on the box.
+
+Taking point 2 would be unsatisfactory for Qiskit SDK.
+Our core transpiler passes can't be aware of all the possible annotations, so custom-annotation authors would either have to do all the compilation work Qiskit usually does for them, or require their users to do that instead.
+That's obviously not suitable from an API perspective.
+
+Point 1 is limiting because it means a backend-specific author can't have an annotation that lets the box use backend-specific information without risking another compiler pass mess it up.
+For example, consider a future where backends are all error corrected and defined in terms of logical qubits, but a backend wants to use some sort of "verbatim" box to allow temporary and very low-level temporary access to the physical qubits (something akin to inline `__asm__` blocks in gcc/clang-flavoured C).
+The core of the idea is that a compiler directive might be either an additive "apply this additional behaviour" marker, or it might be a subtractive "require these temporary restrictions" marker; taking point 1 or point 2 as the default is akin to choose either the former or the latter as the only type of directive permitted, respectively.
+
+Point 3 alone is not great for the same reasons as point 2; an annotation can't know all possible passes.
+That said, a limited subset of this might be possible: an annotation might mark itself as "allow me to be ignored" or "require me to be understood".
+
+> [!IMPORTANT]
+> This needs some more thought, and potentially we'd want to have a set of "predicates" that must be upheld by transpiler passes acting on the box, for example "allow only _these_ passes to inspect it" or "no special action required".
+> We'd probably need helper methods in the pass-manager and pass infrastructure to make it easier to do the right thing in these cases.
+
+We do also have a potential option in that core Qiskit can specify a small number of "special case" annotations, which all passes are required to interpret and respect.
+This gets tricky from a backwards compatibility perspective, though - if we add a new one of these special annotations in Qiskit 1.3, say, it might invalidate code that worked happily in Qiskit 1.2.
+
+
+### Serialisation and deserialisation of annotations
+
+If we allow arbitrary annotations, we reasonably need some way of constructing / deconstructing these, without sending arbitrary code to be executed over the wire - that would be a huge security hole.
+This is the problem that QPY solves for circuits.
+The general principle is that we can rely on reconstruction on the far side of a network boundary, if the receiver only runs code that it chose to install ahead of time.
+`pickle` is not suitable for this.
+
+In this model, QPY would need to be extended in a way that allows the serialisation and deserialisation of these attributes.
+Two ways of making this extension would be:
+
+* have a plugin interface to QPY, where installed packages can register additional serialisers / deserialisers for annotations.
+* add additional keyword arguments to the `dump`/`load` functions that allow a user to pass in the additional serialisers / deserialisers manually (like how is done for JSON).
+
+Major risks for this in QPY are that both sides of the deserialiser / serialiser would need to have compatible versions of the custom packages available, and that these custom serialisers would need to uphold the same highly stringent backwards compatibility guarantees that QPY supports.
+Because of these risks, the keyword-argument form might be more appropriate, so it is very clear at the point of call that QPY is being extended, and that the caller must be certain that they trust the custom serialisation/deserialisation.
+
+The same sort of logic can be used for import/export from OpenQASM 3, but since that's lossy and we certainly can never make the same guarantees about backwards compatibility with that, it's rather less of a security and compatibility concern.
+For clarity, OpenQASM 3 already includes the concept of backend-specific annotations, like
+```openqasm3
+OPENQASM 3.0;
+include "stdgates.inc";
+
+@ibm twirl
+box {
+    cx $0, $1;
+}
+```
+
+Certain hardware providers may also have direct-access APIs that do not require submission of the job via Qiskit.
+Custom serialisers/deserialisers of annotations should be aware of this as well; it is effectively the same problem as serialisation to and from OpenQASM 3.
+
+
+### Communication of "allowed" annotations from a backend
+
+For hardware instructions, we use the `Target` to represent the ISA of a given QPU.
+A `box` annotation remaining on a circuit after Qiskit SDK transpilation implies that the backend will do further processing on the circuit to prepare this for execution.
+This can be associated with further processing by the "quantum computer" before final compilation to the QPU.
+
+In IBM's specified terminology, a "quantum computer" is the full execution environment that a user interacts with to submit quantum jobs to, and might perform further circuit processing, error mitigation, etc, as part of passing the circuit down to the control hardware.
+A "QPU" is more of a representation of the control hardware itself.
+
+In Qiskit SDK, a `Target` represents a QPU, while we might (but have not necessarily yet done so) associate the `Backend` with what we call the entire "quantum computer".
+As an annotation implies further processing by the quantum computer before execution by the QPU, the information on what annotations may be left in the circuit by the transpiler should be drawn from new information specified by the quantum computer, not the particular QPU.
+
+The transpiler should fail if a user or a pass in its pass manager inserts annotations on boxes that the backend does not support, and are not removed by the end of the transpilation.
+We need a way to communicate this information from backends to Qiskit SDK.
+
+For example, an advanced user might attempt to compile an `Estimator` pub with explicit IBM-specific markings of how the noise learning should be performed.
+The compilation of a pub represents partial compilation for a particular quantum computer, which will in turn perform further processing to turn this into the set of circuits that will actually be run on the QPU, and so Qiskit SDK's transpiler perhaps ought to have a similar specification of what constitutes "valid" output of such a compilation for quantum-computer processing, much like `Target` represents what constitues valid output for QPU processing.
+
+#### Very very rough sketch of how this might motivate a `BackendV3`
+
+> [!NOTE]
+> This is a _very vague_ sketch, I'm just trying to make sure we have a clear definition of what a `Target` is, and we don't start having it become so abstract that it is no longer a good model for a QPU.
+> This is absolutely not necessary to finalise for this RFC, but I feel like it's worth thinking about this as a joined-up story, since previously we have treated the output of `transpile` as "ready for QPU execution", but annotations stymie that.
+
+If we go this route, this might motivate a `BackendV3` definition which includes information on what annotations should be permitted to remain.
+This has some benefits:
+
+* the transpiler can reject the output from malformed pass-manager pipelines, or input circuits where the user put on a custom annotation that the backend does not know how to resolve.  This allows client-side validation of the circuits.
+* the QPY API could be extended to retrieve the serialisers/deserialisers from a `backend` object, rather than needing a user to construct it themselves.
+
+If we _truly_ associated the Qiskit object `Backend` with a "quantum computer" (as opposed to `Target`'s QPU), we might even consider an API where the primitives entry points are moved onto the `BackendV3` object, as in:
+
+```python
+class BackendV3:
+    @property
+    @abstractmethod
+    def target(self) -> Target: ...
+    @abstractmethod
+    def allowed_annotations(self) -> AnnotationChecker: ...
+    @abstractmethod
+    def sample(self, sampler_pub_likes) -> SamplerJob: ...
+    @abstractmethod
+    def estimate(self, estimator_pub_likes) -> EstimatorJob: ...
+```
+
+This might naturally extend to such a `BackendV3` providing the additional information that is needed for Qiskit SDK to safely transpile entire sampler and estimator pubs; the compilation of a pub _also_ implies further processing will be done by a quantum computer, just like an annotation remaining in a single circuit.
+
+
+## Case study: noise learning in `pec-runtime`
+
+We envision two main workflows that users will follow once `Box`es become available, one for regular users and another one for power users:
+
 1. The workflow for regular users:
     - Users initialize a `QuantumCircuit` without blocks, as they do today.
     - They apply all of the desired transpiler passes, for example to map the circuit to an ISA circuit for the backend that they wish to use.
-    - They use (a convenience method built around) a new transpiler pass that collects the circuit's gates into blocks, with the ability of specifying different collection strategies.
+    - They use (a convenience method built around) a new transpiler pass that collects the circuit's gates into boxes, with the ability of specifying different collection strategies.
     - They submit their job.
 2. The workflow for power users:
     - Users initialize a `QuantumCircuit` adding blocks manually as they wish.
@@ -52,103 +298,3 @@ In addition to supporting the two workflow above, we believe that the following 
     - The server creates blocks for the users "behind the scenes."
 
 This workflow essentially takes the same steps as are taken today and therefore presents the same disadvantages discussed above, and also violates the principle "don't do hidden transpilation server-side".
-
-Having described motivation and use cases for circuit blocks, we can now provide details regarding their implementation.
-
-## `Block` as an `Instruction`
-In this implementation, `Block` are `Instruction` objects that can be initialized from a circuit.
-```python
-class Block(Instruction):
-    """A container for an isolated block of operations in a larger circuit.
-    
-    Args:
-        circuit: A quantum circuit containing all the operations in the block.
-        twirling_strategy: Some specification of a twirling group (such as "pauli")
-            and of a twirling mode (such as "active-accum") to apply to this block.
-        noise_handle: A mapping object that maps a unique identifier of this block to a noise model.
-        label: A label.
-    """
-
-    def __init__(self, circuit: QuantumCircuit, twirling_strategy, noise_handle, label: str = ""):
-        self._circuit = circuit
-        self._twirling_strategy = twirling_strategy
-        self._noise_handle = noise_handle
-
-        super().__init__(
-            "block",
-            self.circuit.num_qubits,
-            self.circuit.num_clbits,
-            params=self.circuit.parameters,
-            label=label,
-        )
-```
-
-Being `Instruction`s, they can be appended to `QuantumCircuit`s simply by specifying the lists of `qargs` and `clargs`, for example via a dedicated `block` function wrapping the `append` method of `QuantumCircuit`:
-```python
-class QuantumCircuit:
-    ...
-
-    def block(
-        self, 
-        circuit: QuantumCircuit,
-        ...,  # the other inputs required by `Block`s
-        qargs: Optional[list[QubitSpecifier]] = None,
-        cargs: Sequence[ClbitSpecifier] | None = None,
-    ) -> InstructionSet:
-        from .block import Block
-
-        # These use a `dict` not a `set` to guarantee a deterministic order to the arguments.
-        qargs = tuple(
-            {q: None for qarg in qargs for q in self._qbit_argument_conversion(qarg)}
-        )
-        cargs = tuple(
-            {b: None for carg in cargs for b in self._clbit_argument_conversion(carg)}
-        )
-
-        return self.append(Block(circuit, ...), qargs, cargs)
-```
-
-The logic in the `block` function above returns an `InstructionSet` containing a single `CircuitInstruction`, with the block as `operation` and the correct register's slices as `qubits` and `clbits`:
-```python
-block = QuantumCircuit(2)
-block.cx(1, 0)
-
-qreg1 = QuantumRegister(3, "qreg1")
-qreg2 = QuantumRegister(3, "qreg2")
-
-circuit = QuantumCircuit(qreg1, qreg2)
-circuit.s(qreg1[1])
-circuit.h(qreg2[1])
-my_block = circuit.block(block, [1, 5])
-# equivalent to: my_block = circuit.block(block, [qreg1[1], qreg2[2]])
-
-print(my_block[0])
->>> "CircuitInstruction(operation=Instruction(name='block', num_qubits=2, num_clbits=0, params=[]), qubits=(Qubit(QuantumRegister(3, 'qreg1'), 1), Qubit(QuantumRegister(3, 'qreg2'), 2)), clbits=())"
-
-print(circuit.draw())
->>> qreg1_0: ────────────────
->>>          ┌───┐┌────────┐
->>> qreg1_1: ┤ S ├┤0       ├─
->>>          └───┘│        │
->>> qreg1_2: ─────┤        ├─
->>>               │        │
->>> qreg2_0: ─────┤  Block ├─
->>>          ┌───┐│        │
->>> qreg2_1: ┤ H ├┤        ├─
->>>          └───┘│        │
->>> qreg2_2: ─────┤1       ├─
->>>               └────────┘
-```
-
-## Outstanding questions:
-1. In the existing implementation of blocks that exists in `pec-runtime`, blocks are hashable, so that they can be used as keys in dictionaries (specifically in the dictionary porduced by the `NoiseLearner` that maps blocks to noise models). This is clearly unsafe since circuits are mutable. How can we design the noise handle so that it is safer than that, but also more flexible (e.g., if users want to mutate the block but still assign the same noise to it during mitigation, they should be allowed to do so)?
-2. Should `Block` be added to qiskit core, alongside the transpiler pass groups gates in blocks workflow 1? If so, should they be written in Rust or Python?
-3. What packages and subpackages need to be modified once `Block` is introduced? For example, should we add logic to qiskit-aer to be able to simulate circuits with blocks, or to Qiskit's optimizer, ..?
-4. How and when do we communicate the "scope of a block context"? For example, suppose a block context is only sensibly defined for depth-1 blocks of entanglers. Do we let this thing be instantiated with anything and raise during execution, or do we raise immediately? Who is in charge of validation?
-5. How can we (should we?) facilitate re-use of CircuitInstruction or Block instances? For example, suppose we want the same block in a circuit 100 times:
-```python
-for _ in range(100):
-    with circuit.block(context=my_context, name="foo") as block:
-        block.h(0) 
-        block.cx(0, 1)
-```

--- a/0022-circuit-block.md
+++ b/0022-circuit-block.md
@@ -1,12 +1,13 @@
-# Introducing `Block`s in qiskit
+# Introducing `Box`es in Qiskit
 
 | **Status**        | **Proposed** |
 |:------------------|:---------------------------------------------|
 | **RFC #**         | 0022                                         |
-| **Authors**       | [Sam Ferracin](sam.ferracin@ibm.com), [Ian Hincks](ian.hincks@ibm.com), [Chris Wood](cjwood@ibm.com), [Jake Lishman](jake.lishman@ibm.com), [Joshua Skanes-Norman](joshua.sn@ibm.com)    |
+| **Authors**       | [Sam Ferracin](sam.ferracin@ibm.com), [Ian Hincks](ian.hincks@ibm.com), [Jake Lishman](jake.lishman@ibm.com), [Joshua Skanes-Norman](joshua.sn@ibm.com)    |
 | **Submitted**     | YYYY-MM-DD                                   |
 
 ## Summary
+
 Objective: Introduce a new `Block` instruction to enhance the user experience with Qiskit's Runtime primitives, with the goal of providing more flexibility and transparency with respect to twirling and mitigation.
 
 The concept of a block of gates is fundamental to many quantum computing routines. For example, a block is a natural concept when reasoning about quantum errors because the error profile often depends on factors such as which gates are applied simultaneously. However, Qiskit does not provide a dedicated object to represent a block. Traditionally, users have worked around this by defining blocks *indirectly* using barriers. While this approach has been adequate for tasks like scheduling and transpilation, barriers can be hard to parse when pre-processing circuits in preparation for twirling or mitigation. Suboptimal handling of barriers in these post-processing steps can introduce significant slowdowns in some mitigation experiments (for example, it can unnecessarily increase the time required by the noise learning steps) and produce outcomes that may seem unintuitive to typical users.

--- a/0022-circuit-block.md
+++ b/0022-circuit-block.md
@@ -39,7 +39,7 @@ As in OpenQASM 3, a `Box` will be:
 
 * a group of non-overlapping (but potentially nested) circuit instructions,
 * which introduces a new scope for declared variables,
-* which can have internal scheduling within itself, but it scheduled atomically within the circuit (i.e. all wires touched within the box are delayed to match the critical path length),
+* which can have internal scheduling within itself, but is scheduled atomically within the circuit (i.e. all wires touched within the box are delayed to match the critical path length),
 * which forbids optimisations from crossing from outside to inside the box or vice-versa, but permits optimisations across the entire box,
 * and can have arbitrary backend- and SDK-agnostic annotations attached to it.
 


### PR DESCRIPTION
This fleshes out a lot more details about how a generic `box` would work in Qiskit SDK, and how arbitrary downstream annotations might work in the context of an entire compiler framework, where annotation-creating passes may be injected inbetween standard Qiskit passes, or the user may write into their circuit, and the transpiler might want to verify before submission to the quantum computer.

The case study on how `pec-runtime` will use this isn't fleshed out - I mostly just moved it into a section at the end and left it.